### PR TITLE
Fix: kabi downloading by RHEL release version

### DIFF
--- a/rhel-kernel-get
+++ b/rhel-kernel-get
@@ -253,7 +253,6 @@ def get_kernel_source(version):
     # (e.g. 3.10.0-655.el7) it must be downloaded from Brew (StrictVersion will
     # raise exception on such version string). If Brew is unavailable,
     # download from CentOS.
-    version = rhel_kernel_versions.get(version, version)
     try:
         StrictVersion(version)
         tarname = get_kernel_tar_from_upstream(version)
@@ -378,11 +377,14 @@ cwd = os.getcwd()
 tmp = mkdtemp()
 os.chdir(tmp)
 
+# Getting version
+version = rhel_kernel_versions.get(args.version, args.version)
+
 # Download source
-kernel_dir = get_kernel_source(args.version)
+kernel_dir = get_kernel_source(version)
 
 # Patch and configure
-config_file = get_config_file(args.version)
+config_file = get_config_file(version)
 if config_file:
     os.rename(config_file, os.path.join(kernel_dir, ".config"))
 os.chdir(kernel_dir)
@@ -395,7 +397,7 @@ os.chdir(tmp)
 # Extract KABI list
 if args.kabi:
     kabi_filenames = ["kabi_whitelist_x86_64", "kabi_stablelist_x86_64"]
-    kabi_file = get_kabi_file(args.version, kabi_filenames)
+    kabi_file = get_kabi_file(version, kabi_filenames)
     if kabi_file:
         os.rename(kabi_file, os.path.join(kernel_dir,
                                           os.path.basename(kabi_file)))


### PR DESCRIPTION
When downloading by RHEL release version (eg. 8.3), the kabi list was not downloaded because the release version was not translated to kernel version (eg. 4.18.0-240.el8). This PR fixes it.