### PR TITLE
Fix running script on newer python versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+packaging
 progressbar

--- a/rhel-kernel-get
+++ b/rhel-kernel-get
@@ -8,7 +8,7 @@ Steps:
 """
 
 from argparse import ArgumentParser
-from distutils.version import StrictVersion
+from packaging.version import Version
 from progressbar import ProgressBar, Percentage, Bar
 from socket import gethostbyname, error as socket_error
 from subprocess import check_call, check_output, Popen, PIPE, \
@@ -163,7 +163,7 @@ def get_kernel_tar_from_upstream(version):
 
     # Version directory (different naming style for versions under and
     # over 3.0)
-    if StrictVersion(version) < StrictVersion("3.0"):
+    if Version(version) < Version("3.0"):
         url += "v{}/".format(version[:3])
     else:
         url += "v{}.x/".format(version[:1])
@@ -250,12 +250,12 @@ def get_kernel_source(version):
     """Download the sources of the required kernel version."""
     # Deduce source where kernel will be downloaded from.
     # The choice is done based on version string, if it has the release part
-    # (e.g. 3.10.0-655.el7) it must be downloaded from Brew (StrictVersion will
+    # (e.g. 3.10.0-655.el7) it must be downloaded from Brew (Version will
     # raise exception on such version string). If Brew is unavailable,
     # download from CentOS.
     version = rhel_kernel_versions.get(version, version)
     try:
-        StrictVersion(version)
+        Version(version)
         tarname = get_kernel_tar_from_upstream(version)
     except ValueError:
         try:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 
 setup(
     name = "rhel-kernel-get",
-    version = "0.1",
+    version = "0.2",
     description = "A tool for downloading and preparing RHEL kernels",
     author = "Viktor Malik",
     author_email = "vmalik@redhat.com",


### PR DESCRIPTION
This PR fixes the script so it can be run by newer Python versions (v3.13+).
I tested that the script works by downloading `4.18.0-80.el8`, and did not find any problem.

After merging this PR, it will probably also be necessary to add tag `v0.2` to the latest commit, to make it possible use the updated script in DiffKemp (in `nix develop .#test-kernel-buildenv`).